### PR TITLE
Build package before publishing

### DIFF
--- a/.github/workflows/lerna.yml
+++ b/.github/workflows/lerna.yml
@@ -27,7 +27,8 @@ jobs:
         run: |
           npm run setup
 
-      - name: Build packages
+      - name: Build package
+        working-directory: ./packages/product-viewer
         run: |
           npm run build
 

--- a/.github/workflows/lerna.yml
+++ b/.github/workflows/lerna.yml
@@ -27,6 +27,10 @@ jobs:
         run: |
           npm run setup
 
+      - name: Build packages
+        run: |
+          npm run build
+
       - name: Publish lerna
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We need to build the project before publishing it so that the JavaScript (`dist/` and `lib/` folders) are included.  Initially, only the TypeScript was getting shipped. I've tested including this in another project and it fixed the problem.

Right now I'm running `npm run build` in the project root, which builds all 3 sub packages, even though we do not need to actually build `viewer-demos` (to publish `product-viewer`).  Any thoughts if this is worth updating?