### PR TITLE
fix: change workflow branch references to main

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "Code Scanning - Action"
 
 on:
   push:
-    branches: [develop]
+    branches: [main]
   pull_request:
-    branches: [develop]
+    branches: [main]
   schedule:
     - cron: '30 1 * * 0'
 

--- a/.github/workflows/deploy-demos.yml
+++ b/.github/workflows/deploy-demos.yml
@@ -3,7 +3,7 @@ name: Deploy Viewer Demos
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 env:

--- a/.github/workflows/lerna.yml
+++ b/.github/workflows/lerna.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: develop
+          ref: main
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -3,8 +3,7 @@ name: Linting
 on:
   push:
     branches:
-      - develop
-      - master
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,7 @@ name: Tests
 on:
   push:
     branches:
-      - develop
-      - master
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/veracode-analysis.yml
+++ b/.github/workflows/veracode-analysis.yml
@@ -2,7 +2,7 @@ name: Veracode Analysis
 on: 
   push:
     branches: 
-      - develop
+      - main
     paths-ignore:
       - README.md
   pull_request:


### PR DESCRIPTION
This PR fixes outdated references to `develop` branch and replaces them with `main`.

-   [x] I've added a unit test to test for potential regressions of this bug.
-   [x] The changelog has been updated, if applicable.
-   [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

